### PR TITLE
Update interceptor.js.

### DIFF
--- a/src/scripts/interceptor.js
+++ b/src/scripts/interceptor.js
@@ -207,4 +207,4 @@
 
 // run the original application entry point
 
-require(process.argv[1]);
+require('child_process').spawn(process.argv[0], process.argv.slice(1));


### PR DESCRIPTION
 Change require to a dynamic import.
Fixes [this issue](https://stackoverflow.com/questions/72407165/nodejs-error-using-import-with-iisnode), with the fix described in the answer